### PR TITLE
Add salt-call function

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ To run a single test:
 `cshell arch` <-- Gives you a shell in an Arch container
 
 `cexec arch` <-- Gives you a shell in an already running Arch container (use after cshell)
+
+`csalt ubuntu14 state.sls test` <-- Run any salt-call command. caslt <os> <cmd> <args>

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ To run a single test:
 
 `cexec arch` <-- Gives you a shell in an already running Arch container (use after cshell)
 
-`csalt ubuntu14 state.sls test` <-- Run any salt-call command. caslt <os> <cmd> <args>
+`csalt-call ubuntu14 state.sls test` <-- Run any salt-call command. caslt <os> <cmd> <args>

--- a/docker_salt.zsh
+++ b/docker_salt.zsh
@@ -1,3 +1,5 @@
+LOCAL_FILEROOTS="/srv/salt"
+
 if [[ -e /usr/bin/sw_vers && `/usr/bin/sw_vers -productName` == "Mac OS X" ]]; then
     SUDO=""
     DOCKER="/usr/local/bin/docker"
@@ -53,7 +55,14 @@ ctest_func() {
     fi
 }
 
+csalt_cmd_func() {
+    local image=$1
+    local salt_cmd=$2
+    local salt_args=$3
+    $SUDO $DOCKER run --name salt-$image --rm -itv ~/devel/salt/:/testing -v ${LOCAL_FILEROOTS}:/srv/salt/ salt-$image salt-call --local ${salt_cmd} ${salt_args}
+}
+
 alias cshell='csalt_func'
 alias cexec='cexec_func'
 alias cts='ctest_func'
-
+alias csalt='csalt_cmd_func'

--- a/docker_salt.zsh
+++ b/docker_salt.zsh
@@ -55,7 +55,7 @@ ctest_func() {
     fi
 }
 
-csalt_cmd_func() {
+csalt-call_cmd_func() {
     local image=$1
     local salt_cmd=$2
     local salt_args=$3
@@ -65,4 +65,4 @@ csalt_cmd_func() {
 alias cshell='csalt_func'
 alias cexec='cexec_func'
 alias cts='ctest_func'
-alias csalt='csalt_cmd_func'
+alias csalt-call='csalt-call_cmd_func'


### PR DESCRIPTION
I know this will have a merge conflict once #5 is merged. Please merge that one and then I will resolve the conflict here. Thanks

This will give the user the ability to run any salt-call --local command with args. For example:

`csalt-call ubuntu14 state.sls test` will run `state.sls` with the argument `test` from the /srv/salt/ directory on your local VM. 

Here is an example of a use case:

```
 ch3ll@thecakeisalie  ~/git/barnacle   add_sls_func  csalt-call ubuntu14 test.arg testarg
[WARNING ] Although 'dmidecode' was found in path, the current user cannot execute it. Grains output might not be accurate.
[WARNING ] /usr/lib/python2.7/dist-packages/salt/grains/core.py:1493: DeprecationWarning: The "osmajorrelease" will be a type of an integer.

local:
    ----------
    args:
        - testarg
    kwargs:
        ----------
        __pub_fun:
            test.arg
        __pub_jid:
            20160916160841558552
        __pub_pid:
            1
        __pub_tgt:
            salt-call
```