### PR TITLE
Add a vim install to the distribution Dockerfiles

### DIFF
--- a/cent5/Dockerfile
+++ b/cent5/Dockerfile
@@ -3,14 +3,14 @@ FROM centos:5
 COPY base.txt /base.txt
 COPY dev_python27.txt /dev_python27.txt
 
-RUN yum -y install wget gcc zlib-devel openssl-devel cpio expat-devel gettext-devel make
+RUN yum -y install wget gcc zlib-devel openssl-devel cpio expat-devel gettext-devel make vim
 RUN wget https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el5.noarch.rpm
 RUN rpm -ivh salt-repo-latest-1.el5.noarch.rpm
 RUN rm -f salt-repo-latest-1.el5.noarch.rpm
 RUN yum clean expire-cache
 
 RUN yum -y install salt-master
-RUN  yum -y install salt-minion
+RUN yum -y install salt-minion
 RUN yum -y install salt-ssh
 RUN yum -y install salt-syndic
 RUN yum -y install salt-cloud

--- a/cent7/Dockerfile
+++ b/cent7/Dockerfile
@@ -8,7 +8,7 @@ RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el7.
 RUN yum clean expire-cache
 
 RUN yum -y install salt-master
-RUN  yum -y install salt-minion
+RUN yum -y install salt-minion
 RUN yum -y install salt-ssh
 RUN yum -y install salt-syndic
 RUN yum -y install salt-cloud
@@ -18,6 +18,8 @@ RUN yum -y install epel-release
 
 RUN yum -y install python-pip
 RUN yum -y install python-devel
+
+RUN yum -y install vim
 
 RUN pip install -r /dev_python27.txt
 

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -11,7 +11,11 @@ COPY saltstack.list /etc/apt/sources.list.d/saltstack.list
 
 RUN apt-get update
 
+# Install Salt packages
 RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud salt-api
+
+# Install other useful packages
+RUN apt-get -y install vim
 
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt

--- a/leap421/Dockerfile
+++ b/leap421/Dockerfile
@@ -9,7 +9,11 @@ RUN zypper --non-interactive  ar http://download.opensuse.org/repositories/syste
 
 RUN zypper --non-interactive --gpg-auto-import-keys refresh
 
+# Install Salt packages
 RUN zypper --non-interactive in salt-master salt-minion salt-ssh salt-syndic salt-cloud salt-api
+
+# Install other useful packages
+RUN zypper --non-interactive in vim
 
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt

--- a/tumbleweed/Dockerfile
+++ b/tumbleweed/Dockerfile
@@ -9,7 +9,11 @@ RUN zypper --non-interactive  ar http://download.opensuse.org/repositories/syste
 
 RUN zypper --non-interactive --gpg-auto-import-keys refresh
 
+# Install Salt packages
 RUN zypper --non-interactive in salt-master salt-minion salt-ssh salt-syndic salt-cloud salt-api
+
+# Install other useful packages
+RUN zypper --non-interactive in vim
 
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt

--- a/ubuntu12/Dockerfile
+++ b/ubuntu12/Dockerfile
@@ -12,7 +12,11 @@ COPY saltstack.list /etc/apt/sources.list.d/saltstack.list
 
 RUN apt-get update
 
+# Install Salt packages
 RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud salt-api
+
+# Install other helpful packages
+RUN apt-get -y install vim
 
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt

--- a/ubuntu14/Dockerfile
+++ b/ubuntu14/Dockerfile
@@ -11,7 +11,11 @@ COPY saltstack.list /etc/apt/sources.list.d/saltstack.list
 
 RUN apt-get update
 
+# Install Salt packages
 RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud salt-api
+
+# Install other helpful packages
+RUN apt-get -y install vim
 
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt

--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -11,7 +11,11 @@ COPY saltstack.list /etc/apt/sources.list.d/saltstack.list
 
 RUN apt-get update
 
+# Install Salt packages
 RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud salt-api
+
+# Install other helpful packages
+RUN apt-get -y install vim
 
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt


### PR DESCRIPTION
One thing I keep running into when checking if various changes are happening or debugging problems on the containers themselves when using the containers interactively is that vim isn't already installed on these containers.

I've added the vim install to the Dockerfile for most of the currently available distributions.