### PR TITLE
add env variable to use salt from git checkout in testing

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -7,4 +7,7 @@ RUN pacman -Syy
 RUN pacman -S --noconfirm python2-pip gcc git openssl
 RUN pip2 install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing

--- a/cent5/Dockerfile
+++ b/cent5/Dockerfile
@@ -32,5 +32,7 @@ RUN easy_install-2.6 pip
 
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
 
 VOLUME /testing

--- a/cent7/Dockerfile
+++ b/cent7/Dockerfile
@@ -4,7 +4,7 @@ COPY base.txt /base.txt
 COPY dev_python27.txt /dev_python27.txt
 
 RUN yum -y install wget gcc git
-RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el7.noarch.rpm 
+RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el7.noarch.rpm
 RUN yum clean expire-cache
 
 RUN yum -y install salt-master
@@ -20,5 +20,8 @@ RUN yum -y install python-pip
 RUN yum -y install python-devel
 
 RUN pip install -r /dev_python27.txt
+
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
 
 VOLUME /testing

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -16,4 +16,7 @@ RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud s
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing

--- a/fedora24/Dockerfile
+++ b/fedora24/Dockerfile
@@ -7,4 +7,7 @@ RUN dnf -y install wget gcc git redhat-rpm-config salt-master salt-minion salt-s
 
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing

--- a/leap421/Dockerfile
+++ b/leap421/Dockerfile
@@ -14,4 +14,7 @@ RUN zypper --non-interactive in salt-master salt-minion salt-ssh salt-syndic sal
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing

--- a/tumbleweed/Dockerfile
+++ b/tumbleweed/Dockerfile
@@ -14,4 +14,7 @@ RUN zypper --non-interactive in salt-master salt-minion salt-ssh salt-syndic sal
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing

--- a/ubuntu12/Dockerfile
+++ b/ubuntu12/Dockerfile
@@ -17,4 +17,7 @@ RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud s
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing

--- a/ubuntu14/Dockerfile
+++ b/ubuntu14/Dockerfile
@@ -16,4 +16,7 @@ RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud s
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing

--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -16,4 +16,7 @@ RUN apt-get -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud s
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+
 VOLUME /testing


### PR DESCRIPTION
This will ensure that when working with these containers salt is run from /testing/ instead of from the package install. 

At first I thought for sure we wanted to make this the default behavior but then i ran into a use case today when triaging. It was very nice to just have the package install 2016.3.3 already installed on the image so i could push my test case up to docker hub and salt was already installed and a user would not have to learn barnacle to work with the image or know that they needed to add their local git clone repo to /testing as a volume. So I see a couple of options here:

1. continue with adding these env variables as the default and add an optional argument to remove these env variables on all the zshrc functions so they are removed on start of container
2. do not make this the default and add an optional argument to add these env variables in the zshrc functions that is run at time of the container
3. add an alias to the dockerfile that I can easily run to remove these env variables when interacting with the container so if i need to push this up during triage I can just quickly run that alias to remove env variables and reference the salt packaging.
4. Just assume one would need to know these environment varilabes are set and they would need to manually remove them in container if not interacting with local git salt clone and document this

Thoughts? @cachedout @gtmanfred or @rallytime 

