### PR TITLE
add python2 symlink for arch Dockerfile

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -7,6 +7,9 @@ RUN pacman -Syy
 RUN pacman -S --noconfirm python2-pip gcc git openssl
 RUN pip2 install -r /dev_python27.txt
 
+# Add symlink for python2
+RUN ln -s /usr/bin/python2 /usr/bin/python
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
 


### PR DESCRIPTION
When running the arch container when trying to run `python` or `salt` commands it stated python command was not available:

```
[root@813be0606d1f /]# python --version
bash: python: command not found
```

This is because python is `python2` on this image, so needed to add a symlink to ensure everything works now.
