### PR TITLE
add ability to setup specific salt setups

### DIFF
--- a/auto_build.sh
+++ b/auto_build.sh
@@ -6,8 +6,8 @@ ALL_DIRS=$(find ${CURRENT_DIR} -name Dockerfile -printf '%h\n' | for i in `xargs
 function usage()
 {
         echo "=========USAGE========="
-        echo "$0 -o <os> -a <all os>"
-        echo "You can only use -o or -a not both"
+        echo "$0 -o <os> -a <all os> -s <salt setup>"
+        echo "You can only use -o, -s or -a not both"
         echo "When specifying -o you need to simply specify the OS/dir name you want to build"
         echo "Your options for os are the following:"
         echo "${ALL_DIRS}"
@@ -15,13 +15,23 @@ function usage()
         echo '      ./build.sh  -a'
         echo "When specifying -o <os> this will build just that OS in this repo"
         echo '      ./build.sh  -o "centos5'
+        echo "When specifying -s <salt setup> -t <setup type> it will build a specific salt setup"
+        echo "For example running -s api -t cherrypy will build a docker image with cherrypy api setup"
+        echo "The current salt setups available are as follows:"
         exit
 }
 
-while getopts "o:ah" opt; do
+while getopts "o:s:t:ah" opt; do
   case $opt in
     o)
       OS=${OPTARG}
+      ;;
+    s)
+      SETUP=True
+      ARCH=${OPTARG}
+      ;;
+    t)
+      ARCH_TYPE=${OPTARG}
       ;;
     a)
       ALL=True
@@ -52,9 +62,27 @@ function build_os() {
     docker build -t salt-${specific_os} .
 }
 
+function build_setup() {
+    f_arch=$1
+    f_arch_type=$2
+    dockerfile_template="${CURRENT_DIR}/salt_arch/"
+    tmp_dir="/tmp/${f_arch}/${f_arch_type}/"
 
-if [ -z ${OS} ] && [ -z ${ALL} ]; then
+    echo "Creating temp build directory"
+    mkdir -p ${tmp_dir}
+    cp -r ${dockerfile_template}/* ${tmp_dir}
+    cd ${tmp_dir}
+    sed -i -e "s/SALT_ARCH/${f_arch}/g" -e "s/TYPE_OF_ARCH/${f_arch_type}/g" Dockerfile
+
+
+    echo "BUILDING ${f_arch}-${f_arch_type}"
+    docker build -t salt-${f_arch}-${f_arch_type} .
+}
+
+
+if [ -z ${OS} ] && [ -z ${ALL} ] && [ -z ${ARCH} ]; then
     usage
 fi
 [[ ! -z ${OS} ]] && build_os ${OS}
+[[ ! -z ${SETUP} ]] && build_setup ${ARCH} ${ARCH_TYPE}
 [[ ! -z ${ALL} ]] && build_all

--- a/salt_arch/Dockerfile
+++ b/salt_arch/Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:7
+
+COPY base.txt /base.txt
+COPY dev_python27.txt /dev_python27.txt
+COPY salt_setup /tmp/salt_setup/
+
+RUN yum -y install wget gcc git
+RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el7.noarch.rpm
+RUN yum clean expire-cache
+
+RUN yum -y install salt-master
+RUN yum -y install salt-minion
+RUN yum -y install salt-ssh
+RUN yum -y install salt-syndic
+RUN yum -y install salt-cloud
+RUN yum -y install salt-api
+
+RUN yum -y install epel-release
+
+RUN yum -y install python-pip
+RUN yum -y install python-devel
+
+RUN yum -y install vim
+
+RUN pip install -r /dev_python27.txt
+
+ENV PYTHONPATH=/testing/:/testing/salt-testing/
+ENV PATH=$PATH:/testing/scripts/:/testing/salt/tests/
+RUN salt-call --local --file-root=/tmp/salt_setup/ state.sls SALT_ARCH.TYPE_OF_ARCH
+
+VOLUME /testing

--- a/salt_arch/base.txt
+++ b/salt_arch/base.txt
@@ -1,0 +1,11 @@
+Jinja2
+msgpack-python>0.3
+PyYAML
+MarkupSafe
+requests>=1.0.0
+tornado>=4.2.1
+# Required by Tornado to handle threads stuff.
+futures>=2.0
+# from zmq
+pycrypto
+pyzmq

--- a/salt_arch/dev_python27.txt
+++ b/salt_arch/dev_python27.txt
@@ -1,0 +1,8 @@
+-r base.txt
+
+mock
+boto>=2.32.1
+moto>=0.3.6
+SaltTesting
+psutil
+-e git+https://github.com/s0undt3ch/unittest-xml-reporting.git#egg=unittest-xml-reporting

--- a/salt_arch/salt_setup/api/cherrypy.sls
+++ b/salt_arch/salt_setup/api/cherrypy.sls
@@ -1,0 +1,26 @@
+include:
+  - api.cherrypy.users
+
+add_api_config:
+  file.managed:
+    - name: /etc/salt/master.d/api.conf
+    - contents: |
+        rest_cherrypy:
+          port: 8000
+          disable_ssl: True # Don't do this in production
+          debug: True
+          host: 0.0.0.0
+          webhook_url: /hook
+          webhook_disable_auth: True
+        external_auth:
+          pam:
+            saltdev:
+              - .*
+              - '@runner'
+              - '@wheel'
+              - '@jobs'
+            root:
+              - .*
+              - '@runner'
+              - '@wheel'
+              - '@jobs'

--- a/salt_arch/salt_setup/api/users.sls
+++ b/salt_arch/salt_setup/api/users.sls
@@ -1,0 +1,3 @@
+add_saltdev_user:
+  user.present:
+    - name: saltdev

--- a/salt_arch/sample.xml
+++ b/salt_arch/sample.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite errors="0" failures="0" name="unit.modules.cp_test.CpTestCase-20160910003241" tests="7" time="0.138">
+        <properties/>
+        <system-out>
+<![CDATA[]]>    </system-out>
+        <system-err>
+<![CDATA[]]>    </system-err>
+        <testcase classname="unit.modules.cp_test.CpTestCase" name="test__render_filenames_render_failed" time="0.021"/>
+        <testcase classname="unit.modules.cp_test.CpTestCase" name="test__render_filenames_success" time="0.021"/>
+        <testcase classname="unit.modules.cp_test.CpTestCase" name="test__render_filenames_undefined_template" time="0.018"/>
+        <testcase classname="unit.modules.cp_test.CpTestCase" name="test_get_file_not_found" time="0.018"/>
+        <testcase classname="unit.modules.cp_test.CpTestCase" name="test_get_file_str_success" time="0.021"/>
+        <testcase classname="unit.modules.cp_test.CpTestCase" name="test_push_dir_non_absolute_path" time="0.018"/>
+        <testcase classname="unit.modules.cp_test.CpTestCase" name="test_push_non_absolute_path" time="0.021"/>
+</testsuite>
+


### PR DESCRIPTION
Okay this setup is super rough right now, but hoping to improve on this. I got sick of  re-setting up salt architectures, for example salt-api. So this is an answer to that problem. I still need to add the ability to run this through the .zsh file but will be adding next week.

Now with the autobuild script you can run `./auto_build.sh -s api -t cherrypy` (but as stated before i want to add this to the cbuild command)

This will build a docker image called salt-api-cherrypy and will run the states in `salt_arch/salt_setup/api/cherrypy.sls` which will add a salt-api configuration setup for cherrypy. 

So now you can run `cshell api-cherrpy` and run `salt-api -ldebug` and everything will be setup for you

This will give us the ability to easily add more setups. They just have to follow the same structure of adding a sls file similar to {ARCH}{ARCH-TYPE} (api/cherrpy)..Plan on adding a lot more next week as well, if  this is something we wnat to go forward with.

but wanted to get the idea out there and see if this is a good direction.