### PR TITLE
Update repo paths for centos 6 and 7 distros

### DIFF
--- a/cent6/Dockerfile
+++ b/cent6/Dockerfile
@@ -4,7 +4,7 @@ COPY base.txt /base.txt
 COPY dev_python27.txt /dev_python27.txt
 
 RUN yum -y install wget gcc git vim
-RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el6.noarch.rpm
+RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el6.noarch.rpm
 RUN yum clean expire-cache
 
 RUN yum -y install salt-master

--- a/cent7/Dockerfile
+++ b/cent7/Dockerfile
@@ -4,7 +4,7 @@ COPY base.txt /base.txt
 COPY dev_python27.txt /dev_python27.txt
 
 RUN yum -y install wget gcc git
-RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el7.noarch.rpm
+RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el7.noarch.rpm
 RUN yum clean expire-cache
 
 RUN yum -y install salt-master


### PR DESCRIPTION
The `-1` paths no longer exist. We need to use the `-2` paths now.

http://repo.saltstack.com/yum/redhat/