### PR TITLE
Add systemd support for cent7 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,44 @@ Again, this will operate on your local checkout of the Salt repo so you can
 quickly make changes and then immediatley see how they will work on any given
 platform.
 
+Run a container using systemd
+=============================
+
+**NOTE: currently only supported for the `cent7` image**
+
+To start a container using systemd you need three things:
+
+1. `CAP_SYS_ADMIN`
+2. The container needs read-only access to your cgroups
+3. You need to specify the path to the systemd binary as the command for the
+   container.
+
+For example:
+
+```bash
+docker run --detach --name container_name --cap-add SYS_ADMIN -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v ~/devel/salt:/testing cent7 /usr/lib/systemd/systemd
+```
+
+This will launch the container running systemd and detach from it.
+
+To get a shell, you'll need to ssh into the container. Because Docker re-uses
+IP addresses, you'll want to disable strict host key checking and tell ssh not
+to write to your `known_hosts` file. You'll also need to get the IP address.
+This can all be done via a truly horrific-looking shell one-liner:
+
+```bash
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "root@$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' container_name)"
+```
+
+Once you've connected, use the initial password `changeme` and you'll
+immediately be prompted to set a new password. If you would like to avoid this
+when building your own copy of the container, edit the Dockerfile before
+building. You can simply comment out the `passwd` line and subtitute your own
+preferred password in the `chpasswd` line.
+
+Fortunately, both starting a container under systemd and SSH-ing into it are
+supported via the .zsh aliases described in the section below.
+
 Using .zsh aliases
 ==================
 
@@ -80,6 +118,11 @@ To run a single test:
 
 `cbuild -o <OS>` <-- Builds a specific OS in the repo
 
-`csalt ubuntu14 state.sls test` <-- Run any salt-call command. caslt <os> <cmd> <args>
+`csalt ubuntu14 state.sls test` <-- Run a salt command
 
-`csalt-call ubuntu14 state.sls test` <-- Run any salt-call command. caslt <os> <cmd> <args>
+`csalt-call ubuntu14 state.sls test` <-- Run a salt-call command
+
+`cstart-systemd container_name cent7` <-- Start `container_name` under systemd
+using image `cent7`
+
+`cssh container_name` <-- SSH into `container_name`

--- a/cent7/Dockerfile
+++ b/cent7/Dockerfile
@@ -14,14 +14,25 @@ RUN yum -y install salt-syndic
 RUN yum -y install salt-cloud
 RUN yum -y install salt-api
 
+# Install openssh so we can ssh into the container
+RUN yum -y install openssh-server
+# Set root password to "changeme" and force a change on first login
+RUN echo root:changeme | chpasswd
+RUN passwd --expire root
+
 RUN yum -y install epel-release
 
 RUN yum -y install python-pip
 RUN yum -y install python-devel
 
-RUN yum -y install vim
+RUN yum -y install vim iproute
 
 RUN pip install -r /dev_python27.txt
+
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
 
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH

--- a/docker_salt.zsh
+++ b/docker_salt.zsh
@@ -68,9 +68,39 @@ csalt-call_cmd_func() {
     $SUDO $DOCKER run --name salt-$image --rm -itv ${LOCAL_VOLUME}:/testing -v ${LOCAL_FILEROOTS}:/srv/salt/ salt-$image salt-call --local ${salt_cmd} ${salt_args}
 }
 
+cstart-systemd_func() {
+    local container=$1
+    local image=$2
+    if test -z "$container"; then
+        echo "Missing container name!" 1>&2
+        exit 1
+    fi
+    if test -z "$image"; then
+        echo "Missing image name!" 1>&2
+        exit 2
+    fi
+
+    $SUDO $DOCKER run -d --name $container --cap-add SYS_ADMIN -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v ${LOCAL_VOLUME}:/testing $image /usr/lib/systemd/systemd
+}
+
+cssh_func() {
+    local container=$1
+    if test -z "$container"; then
+        echo "Missing container name!" 1>&2
+        exit 1
+    fi
+
+    local ipaddr=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $container)
+
+    # Disable strict checking because docker will reuse IP addresses
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "root@$ipaddr"
+}
+
 # ALIASES
 alias cshell='csalt_func'
 alias cexec='cexec_func'
 alias cts='ctest_func'
 alias cbuild='cbuild_func'
 alias csalt-call='csalt-call_cmd_func'
+alias cstart-systemd='cstart-systemd_func'
+alias cssh='cssh_func'


### PR DESCRIPTION
This modifies the Dockerfile, installing openssh and setting an expired
default root password. It also adds documentation for starting the cent7
image under systemd, and provides ZSH aliases for starting a container
and SSH-ing into it.