### PR TITLE
Add pudb to all images

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -7,6 +7,11 @@ RUN pacman -Syy
 RUN pacman -S --noconfirm python2-pip gcc git openssl
 RUN pip2 install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip2 install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 # Add symlink for python2
 RUN ln -s /usr/bin/python2 /usr/bin/python
 

--- a/cent5/Dockerfile
+++ b/cent5/Dockerfile
@@ -32,6 +32,11 @@ RUN easy_install-2.6 pip
 
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/cent6/Dockerfile
+++ b/cent6/Dockerfile
@@ -21,6 +21,11 @@ RUN yum -y install python-devel
 
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/debian7/Dockerfile
+++ b/debian7/Dockerfile
@@ -21,6 +21,11 @@ RUN apt-get -y install vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-get -y install vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-get -y install vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/fedora24/Dockerfile
+++ b/fedora24/Dockerfile
@@ -7,6 +7,11 @@ RUN dnf -y install wget gcc git redhat-rpm-config salt-master salt-minion salt-s
 
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/fedora25/Dockerfile
+++ b/fedora25/Dockerfile
@@ -7,6 +7,11 @@ RUN dnf -y install wget gcc git redhat-rpm-config salt-master salt-minion salt-s
 
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/fedora26/Dockerfile
+++ b/fedora26/Dockerfile
@@ -7,6 +7,11 @@ RUN dnf -y install wget gcc git redhat-rpm-config salt-master salt-minion salt-s
 
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing
 ENV PATH=/testing/scripts:/testing/salt/tests:$PATH
 

--- a/leap421/Dockerfile
+++ b/leap421/Dockerfile
@@ -18,6 +18,11 @@ RUN zypper --non-interactive in vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/leap422/Dockerfile
+++ b/leap422/Dockerfile
@@ -18,6 +18,11 @@ RUN zypper --non-interactive in vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/tumbleweed/Dockerfile
+++ b/tumbleweed/Dockerfile
@@ -18,6 +18,11 @@ RUN zypper --non-interactive in vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/ubuntu12/Dockerfile
+++ b/ubuntu12/Dockerfile
@@ -21,6 +21,11 @@ RUN apt-get -y install vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/ubuntu14/Dockerfile
+++ b/ubuntu14/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-get -y install vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 

--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-get -y install vim
 RUN pip install --upgrade pip
 RUN pip install -r /dev_python27.txt
 
+# Install pudb, get rid of welcome message, and turn on line numbers
+RUN pip install pudb
+RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
+RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
+
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
 ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 


### PR DESCRIPTION
Well, all besides cent7, which is being handled via
https://github.com/cachedout/barnacle/pull/32. Since pudb ends up being
installed on almost all containers I use for testing, this just
streamlines the process and makes troubleshooing easier.