### PR TITLE
Update cent6 Dockerfile for python2.7, cffi

### DIFF
--- a/cent6/Dockerfile
+++ b/cent6/Dockerfile
@@ -3,26 +3,18 @@ FROM centos:6
 COPY base.txt /base.txt
 COPY dev_python27.txt /dev_python27.txt
 
-RUN yum -y install wget gcc git vim
+RUN yum -y install epel-release
+RUN yum -y install wget gcc gcc-c++ git vim libffi-devel
 RUN yum install -y https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el6.noarch.rpm
 RUN yum clean expire-cache
 
-RUN yum -y install salt-master
-RUN  yum -y install salt-minion
-RUN yum -y install salt-ssh
-RUN yum -y install salt-syndic
-RUN yum -y install salt-cloud
-RUN yum -y install salt-api
+RUN yum -y install salt-master salt-minion salt-ssh salt-syndic salt-cloud salt-api
 
-RUN yum -y install epel-release
-
-RUN yum -y install python-pip
-RUN yum -y install python-devel
-
-RUN pip install -r /dev_python27.txt
+RUN yum -y install python27-pip python27-devel
+RUN pip2.7 install -r /dev_python27.txt
 
 # Install pudb, get rid of welcome message, and turn on line numbers
-RUN pip install pudb
+RUN pip2.7 install pudb
 RUN sed -i 's/seen_welcome = .\+/seen_welcome = e033/' /root/.config/pudb/pudb.cfg
 RUN sed -i 's/line_numbers = .\+/line_numbers = True/' /root/.config/pudb/pudb.cfg
 

--- a/cent6/dev_python27.txt
+++ b/cent6/dev_python27.txt
@@ -1,5 +1,7 @@
 -r base.txt
 
+# Older cffi needed because newer cffi requires newer libffi
+cffi==0.6
 mock
 apache-libcloud>=0.14.0
 boto>=2.32.1


### PR DESCRIPTION
Also add cffi to the dev_python27.txt, pinned to the version EPEL
provides for Python 2.6. Newer cffi requires newer libffi, so we have
to make sure an older cffi is installed via pip.