### PR TITLE
Remove pycryptodomex since pycryptodome is already present

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -12,12 +12,27 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 # Install Python and other useful utilities
 RUN pacman -Syyu --noconfirm wget curl gcc git openssh python2 python libxml2 libxslt openssl man man-pages vim iproute2
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/arch/requirements.txt
+++ b/arch/requirements.txt
@@ -76,7 +76,7 @@ pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
 pycrypto==2.6.1 ; sys_platform not in "win32,darwin"
-pycryptodome==3.8.1       # via python-jose
+pycryptodome==3.9.7       # via python-jose
 pygit2==1.2.0; python_version >= '3.0'
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/cent6/Dockerfile
+++ b/cent6/Dockerfile
@@ -12,13 +12,28 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 # Install Python and other useful utilities
 RUN yum -y install epel-release https://repo.ius.io/ius-release-el6.rpm
 RUN yum -y install wget curl gcc gcc-c++ git openssh-server python27-devel python36u-devel vim iproute
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/cent6/requirements.txt
+++ b/cent6/requirements.txt
@@ -76,7 +76,7 @@ pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
 pycrypto==2.6.1 ; sys_platform not in "win32,darwin"
-pycryptodome==3.8.1       # via python-jose
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/cent7/Dockerfile
+++ b/cent7/Dockerfile
@@ -12,13 +12,28 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 # Install Python and other useful utilities
 RUN yum -y install epel-release
 RUN yum -y install wget curl gcc gcc-c++ git openssh-server python2-devel python3-devel vim iproute
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/cent7/requirements.txt
+++ b/cent7/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/cent8/Dockerfile
+++ b/cent8/Dockerfile
@@ -12,13 +12,28 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 # Install Python and other useful utilities
 RUN yum -y install epel-release
 RUN yum -y install wget curl gcc gcc-c++ git openssh-server python2-devel python3-devel vim iproute passwd glibc-locale-source glibc-langpack-en
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/cent8/requirements.txt
+++ b/cent8/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/debian10/Dockerfile
+++ b/debian10/Dockerfile
@@ -1,9 +1,11 @@
 FROM debian:buster
 
+# Make sure 32-bit package installs are enabled
+RUN dpkg --add-architecture i386
 # Make sure /var/tmp exists
 RUN test -e /tmp || ln -s /var/tmp /tmp
 # Create some dirs for Salt
-RUN mkdir -p /etc/salt/{master,minion}.d /srv/salt /srv/pillar
+RUN mkdir -p /etc/salt/master.d /etc/salt/minion.d /srv/salt /srv/pillar
 # Point the minion at localhost
 RUN echo "master: localhost" > /etc/salt/minion
 # Create a pillar top file and empty pillar SLS file
@@ -11,6 +13,22 @@ RUN echo "base:\n  test:\n    - test" >/srv/pillar/top.sls
 RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
+
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget curl gcc g++ git openssh-server python-dev python3-dev libgit2-dev libffi-dev libxslt-dev libxml2-dev libssl-dev vim iproute2 less locales
@@ -21,7 +39,6 @@ RUN locale-gen
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/debian10/requirements.txt
+++ b/debian10/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/debian8/Dockerfile
+++ b/debian8/Dockerfile
@@ -1,9 +1,11 @@
 FROM debian:jessie
 
+# Make sure 32-bit package installs are enabled
+RUN dpkg --add-architecture i386
 # Make sure /var/tmp exists
 RUN test -e /tmp || ln -s /var/tmp /tmp
 # Create some dirs for Salt
-RUN mkdir -p /etc/salt/{master,minion}.d /srv/salt /srv/pillar
+RUN mkdir -p /etc/salt/master.d /etc/salt/minion.d /srv/salt /srv/pillar
 # Point the minion at localhost
 RUN echo "master: localhost" > /etc/salt/minion
 # Create a pillar top file and empty pillar SLS file
@@ -11,6 +13,22 @@ RUN echo "base:\n  test:\n    - test" >/srv/pillar/top.sls
 RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
+
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget curl gcc g++ git openssh-server python-dev python3-dev libgit2-dev libffi-dev libxslt-dev libxml2-dev libssl-dev vim iproute2 less locales
@@ -21,7 +39,6 @@ RUN locale-gen
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/debian8/requirements.txt
+++ b/debian8/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/debian9/Dockerfile
+++ b/debian9/Dockerfile
@@ -1,9 +1,11 @@
 FROM debian:stretch
 
+# Make sure 32-bit package installs are enabled
+RUN dpkg --add-architecture i386
 # Make sure /var/tmp exists
 RUN test -e /tmp || ln -s /var/tmp /tmp
 # Create some dirs for Salt
-RUN mkdir -p /etc/salt/{master,minion}.d /srv/salt /srv/pillar
+RUN mkdir -p /etc/salt/master.d /etc/salt/minion.d /srv/salt /srv/pillar
 # Point the minion at localhost
 RUN echo "master: localhost" > /etc/salt/minion
 # Create a pillar top file and empty pillar SLS file
@@ -11,6 +13,22 @@ RUN echo "base:\n  test:\n    - test" >/srv/pillar/top.sls
 RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
+
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget curl gcc g++ git openssh-server python-dev python3-dev libgit2-dev libffi-dev libxslt-dev libxml2-dev libssl-dev vim iproute2 less locales
@@ -21,7 +39,6 @@ RUN locale-gen
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/debian9/requirements.txt
+++ b/debian9/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/fedora30/Dockerfile
+++ b/fedora30/Dockerfile
@@ -12,12 +12,27 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 # Install Python and other useful utilities
 RUN dnf -y install wget curl gcc gcc-c++ git openssh-server python2-devel python3-devel vim iproute passwd
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/fedora30/requirements.txt
+++ b/fedora30/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/fedora31/Dockerfile
+++ b/fedora31/Dockerfile
@@ -12,19 +12,30 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 # Install Python and other useful utilities
 RUN dnf -y install wget curl gcc gcc-c++ git openssh-server python2-devel python3-devel vim iproute passwd glibc-locale-source glibc-langpack-en
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing
-
-# Neither Python 2 nor 3 stake a claim on /usr/bin/python, so point it at
-# Python 3.
-RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Set root password to "changeme" and force a change on first login
 RUN echo root:changeme | chpasswd

--- a/fedora31/requirements.txt
+++ b/fedora31/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/leap151/Dockerfile
+++ b/leap151/Dockerfile
@@ -12,11 +12,26 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 RUN zypper --non-interactive install wget curl gcc gcc-c++ git openssh python-devel python-xml python3-devel libgit2-devel libffi-devel libxslt-devel libxml2-devel vim iproute2
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/leap151/requirements.txt
+++ b/leap151/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/leap152/Dockerfile
+++ b/leap152/Dockerfile
@@ -12,11 +12,26 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 RUN zypper --non-interactive install wget curl gcc gcc-c++ git openssh python-devel python-xml python3-devel libgit2-devel libffi-devel libxslt-devel libxml2-devel vim iproute2
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/leap152/requirements.txt
+++ b/leap152/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/tumbleweed/Dockerfile
+++ b/tumbleweed/Dockerfile
@@ -12,12 +12,27 @@ RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
 
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
+
 RUN zypper --non-interactive dup
 RUN zypper --non-interactive install wget curl gcc gcc-c++ git openssh python-devel python-xml python3-devel libgit2-devel libffi-devel libxslt-devel libxml2-devel vim iproute2
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/tumbleweed/requirements.txt
+++ b/tumbleweed/requirements.txt
@@ -75,9 +75,8 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
-pygit2==0.28.2
+pycryptodome==3.9.7       # via python-jose
+pygit2==1.0.3; python_version >= '3.0'
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0

--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -1,16 +1,34 @@
 FROM ubuntu:16.04
 
+# Make sure 32-bit package installs are enabled
+RUN dpkg --add-architecture i386
 # Make sure /var/tmp exists
 RUN test -e /tmp || ln -s /var/tmp /tmp
 # Create some dirs for Salt
-RUN mkdir -p /etc/salt/{master,minion}.d /srv/salt /srv/pillar
+RUN mkdir -p /etc/salt/master.d /etc/salt/minion.d /srv/salt /srv/pillar
 # Point the minion at localhost
 RUN echo "master: localhost" > /etc/salt/minion
 # Create a pillar top file and empty pillar SLS file
-RUN echo -e "base:\n  test:\n    - test" >/srv/pillar/top.sls
+RUN echo "base:\n  test:\n    - test" >/srv/pillar/top.sls
 RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
+
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
 
 RUN apt-get update
 RUN apt-get -y install wget curl gcc g++ git openssh-server python-dev python3-dev vim iproute less locales
@@ -21,7 +39,6 @@ RUN locale-gen
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/ubuntu16/requirements.txt
+++ b/ubuntu16/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/ubuntu18/Dockerfile
+++ b/ubuntu18/Dockerfile
@@ -1,16 +1,34 @@
 FROM ubuntu:18.04
 
+# Make sure 32-bit package installs are enabled
+RUN dpkg --add-architecture i386
 # Make sure /var/tmp exists
 RUN test -e /tmp || ln -s /var/tmp /tmp
 # Create some dirs for Salt
-RUN mkdir -p /etc/salt/{master,minion}.d /srv/salt /srv/pillar
+RUN mkdir -p /etc/salt/master.d /etc/salt/minion.d /srv/salt /srv/pillar
 # Point the minion at localhost
 RUN echo "master: localhost" > /etc/salt/minion
 # Create a pillar top file and empty pillar SLS file
-RUN echo -e "base:\n  test:\n    - test" >/srv/pillar/top.sls
+RUN echo "base:\n  test:\n    - test" >/srv/pillar/top.sls
 RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
+
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
 
 RUN apt-get update
 RUN apt-get -y install wget curl gcc g++ git openssh-server python-dev python3-dev vim iproute2 less locales
@@ -21,7 +39,6 @@ RUN locale-gen
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/ubuntu18/requirements.txt
+++ b/ubuntu18/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/ubuntu20/Dockerfile
+++ b/ubuntu20/Dockerfile
@@ -1,16 +1,34 @@
 FROM ubuntu:20.04
 
+# Make sure 32-bit package installs are enabled
+RUN dpkg --add-architecture i386
 # Make sure /var/tmp exists
 RUN test -e /tmp || ln -s /var/tmp /tmp
 # Create some dirs for Salt
-RUN mkdir -p /etc/salt/{master,minion}.d /srv/salt /srv/pillar
+RUN mkdir -p /etc/salt/master.d /etc/salt/minion.d /srv/salt /srv/pillar
 # Point the minion at localhost
 RUN echo "master: localhost" > /etc/salt/minion
 # Create a pillar top file and empty pillar SLS file
-RUN echo -e "base:\n  test:\n    - test" >/srv/pillar/top.sls
+RUN echo "base:\n  test:\n    - test" >/srv/pillar/top.sls
 RUN touch /srv/pillar/test.sls
 # Set a predictable minion ID
 RUN echo test >/etc/salt/minion_id
+
+# Create command stubs to ensure Python 3 is the default
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython3 /testing/scripts/$cmd \"\$@\"" >/usr/bin/$cmd; \
+        chmod 0755 /usr/bin/$cmd; \
+    done
+
+# Now do Python 2
+RUN for cmd in salt salt-api salt-call salt-cloud salt-cp salt-extend \
+               salt-key salt-master salt-minion salt-proxy salt-run salt-ssh \
+               salt-syndic salt-unity spm; do \
+        echo "#!/bin/bash\n\npython2 /testing/scripts/$cmd \"\$@\"" >/usr/bin/${cmd}2; \
+        chmod 0755 /usr/bin/${cmd}2; \
+    done
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget curl gcc g++ git openssh-server python-dev python3-dev libgit2-dev libffi-dev libxslt-dev libxml2-dev vim iproute2 less locales
@@ -21,7 +39,6 @@ RUN locale-gen
 
 # Setup environment and UTF-8 locale
 ENV PYTHONPATH=/testing/:/testing/salt-testing/
-ENV PATH=/testing/scripts/:/testing/salt/tests/:$PATH
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8
 VOLUME /testing

--- a/ubuntu20/requirements.txt
+++ b/ubuntu20/requirements.txt
@@ -75,8 +75,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.9.7
+pycryptodome==3.9.7       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko


### PR DESCRIPTION
Additionally, add command stubs to ensure that irrespective of platform,
the salt commands (salt, salt-call, etc.) use Python 3, as well as
counterparts (salt2, salt-call2, etc.) that use Python 2.